### PR TITLE
Get jar from GitHub

### DIFF
--- a/.github/workflows/packer-build-ci.yml
+++ b/.github/workflows/packer-build-ci.yml
@@ -26,28 +26,26 @@ jobs:
       packages: write
 
     name: packer
-
+    
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+          - 32000:5000
+          
+    env:
+      local-repo: localhost:32000/mirc-ctp
+      local-tag: ci
+      
     steps:
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ctp-build
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=sha
-
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,21 +62,30 @@ jobs:
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get -q update && sudo apt-get -yq install packer
-
       - name: Build Artifacts
         run: |
-          [[ -f Makefile ]] && make .state_ctp-docker
-          CHANGED_FILES=$(git diff --name-only ${{github.event.before}}..${{github.event.after}} |grep '\.pkr\.hcl$')
-          for FILE in "${CHANGED_FILES[@]}"; do
-          packer validate -syntax-only "${FILE}"
-          [[ $? -eq 0 ]] && packer build -color=false -on-error=abort "${FILE}"
-          done
+          [[ -f Makefile ]] && make .state_ctp-docker repo=${{ env.local-repo}} tag=${{ env.local-tag }}
+          echo "mirc-ctp-build-ver=$(cat latest-build)" >> $GITHUB_ENV
+          docker push ${{ env.local-repo}}:${{ env.local-tag }}
         env:
           PACKER_LOG: 1
-
+          
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/mirc-ctp
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=sha
+            type=raw,value=${{ env.mirc-ctp-build-ver }}
       - name: Push docker image
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: localhost:32000/ctp-build:ci
+          src: ${{ env.local-repo}}:${{ env.local-tag }}
           dst: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/packer-build-ci.yml
+++ b/.github/workflows/packer-build-ci.yml
@@ -1,3 +1,4 @@
+
 ---
 name: Packer build
 
@@ -26,28 +27,26 @@ jobs:
       packages: write
 
     name: packer
-
+    
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+          - 32000:5000
+          
+    env:
+      local-repo: localhost:32000/mirc-ctp
+      local-tag: ci
+      
     steps:
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ctp-build
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=sha
-
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,21 +63,30 @@ jobs:
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get -q update && sudo apt-get -yq install packer
-
       - name: Build Artifacts
         run: |
-          [[ -f Makefile ]] && make .state_ctp-docker
-          CHANGED_FILES=$(git diff --name-only ${{github.event.before}}..${{github.event.after}} |grep '\.pkr\.hcl$')
-          for FILE in "${CHANGED_FILES[@]}"; do
-          packer validate -syntax-only "${FILE}"
-          [[ $? -eq 0 ]] && packer build -color=false -on-error=abort "${FILE}"
-          done
+          [[ -f Makefile ]] && make .state_ctp-docker repo=${{ env.local-repo}} tag=${{ env.local-tag }}
+          echo "mirc-ctp-build-ver=$(cat latest-build)" >> $GITHUB_ENV
+          docker push ${{ env.local-repo}}:${{ env.local-tag }}
         env:
           PACKER_LOG: 1
-
+          
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/mirc-ctp
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=sha
+            type=raw,value=${{ env.mirc-ctp-build-ver }}
       - name: Push docker image
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: localhost:32000/ctp-build:ci
+          src: ${{ env.local-repo}}:${{ env.local-tag }}
           dst: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/packer-build-ci.yml
+++ b/.github/workflows/packer-build-ci.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - "**.pkr.hcl"
 
+  workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
 
@@ -26,8 +28,21 @@ jobs:
     name: packer
 
     steps:
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ctp-build
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=sha
+
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -60,3 +75,10 @@ jobs:
           done
         env:
           PACKER_LOG: 1
+
+      - name: Push docker image
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: localhost:32000/ctp-build:ci
+          dst: |
+            ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ output_*
 .*.swp
 .state_*
 output-*
+CTP-installer.jar
+latest-build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 source = https://github.com/johnperry/CTP.git
-repo = ghcr.io/australian-imaging-service/mirc-ctp
+repo = localhost:32000/mirc-ctp
 tag = $(shell cat latest-build)
 
 all : .state_ctp-docker .state_ctp-ovf .state_ctp-vagrant .state_ctp-lxd
@@ -9,7 +9,6 @@ all : .state_ctp-docker .state_ctp-ovf .state_ctp-vagrant .state_ctp-lxd
 
 .state_ctp-docker: ctp.pkr.hcl CTP-installer.jar
 	packer build -var='repo=$(repo)' -var='tag=["$(tag)"]' ctp.pkr.hcl
-	# touch .state_ctp-docker
 	
 .state_ctp-ovf : mirc-ctp.json mirc-ctp.service CTP-installer.jar focal-server-cloudimg-amd64.ova nocloud.iso
 	packer build -only=virtualbox-ovf mirc-ctp.json
@@ -28,7 +27,7 @@ CTP-installer.jar:
 	# cp -r CTP-old CTP
 	cd CTP; \
 	version=$$(git log -n 1 --date=format:'%Y%m%d' products/CTP-installer.jar | grep Date | cut -d ' ' -f 4); \
-	echo $$version > ../latest-build
+	echo v$$version > ../latest-build
 	mv CTP/products/CTP-installer.jar ./
 	rm -fr CTP
 

--- a/ctp.pkr.hcl
+++ b/ctp.pkr.hcl
@@ -1,7 +1,7 @@
 build {
   name = "ctp"
   sources = [
-    "source.docker.debian"
+    "source.docker.ctp"
   ]
   provisioner "file" {
     sources = [
@@ -22,19 +22,23 @@ build {
       "rm -f /tmp/CTP-installer.jar"
     ]    
   }
-  post-processor "docker-tag" {
-    repository = var.repo
-    tags = var.tag
+  post-processors {
+    post-processor "docker-tag" {
+      repository = var.repo
+      tags = var.tag
+    }
+    # post-processor "docker-push" {
+    #   only = ["docker.ctp"]
+    # }
   }
 }
 variable "repo" {
   type = string
-  # default = "ghcr.io/australian-imaging-service/mirc-ctp"
 }
 variable "tag" {
   type = list(string)
 }
-source "docker" "debian" {
+source "docker" "ctp" {
   image = "openjdk:8u322-jdk-slim-bullseye"
   commit  = true
   changes = [

--- a/ctp.pkr.hcl
+++ b/ctp.pkr.hcl
@@ -1,21 +1,20 @@
 build {
-  name = "docker"
+  name = "ctp"
   sources = [
-    "source.docker.alpine"
+    "source.docker.debian"
   ]
   provisioner "file" {
     sources = [
       "CTP-installer.jar", 
       "config-serveronly.xml",
       "Launcher.properties",
-      "run.sh"
+      "entrypoint.sh"
     ]
     destination = "/tmp/"
   }
   provisioner "shell" {
     inline = [
-      "apk update",
-      "apk add --no-cache tzdata",
+      "apt update",
       "mkdir -p /JavaPrograms/ && cd /JavaPrograms",
       "jar xf /tmp/CTP-installer.jar CTP",
       "mv /tmp/config-serveronly.xml /JavaPrograms/CTP/config.xml",
@@ -35,14 +34,15 @@ variable "repo" {
 variable "tag" {
   type = list(string)
 }
-source "docker" "alpine" {
-  image = "openjdk:8u212-jdk-alpine3.9"
+source "docker" "debian" {
+  image = "openjdk:18-jdk-slim-bullseye"
+  # image = "openjdk:8u322-jdk-slim-bullseye"
   commit  = true
   changes = [
     "LABEL org.opencontainers.image.source https://github.com/australian-imaging-service/ctp-build",
     "USER root",
     "EXPOSE 1080 1443 25055",
     "WORKDIR /JavaPrograms/CTP",
-    "ENTRYPOINT [\"/bin/sh\", \"/tmp/run.sh\"]"
+    "ENTRYPOINT [\"/bin/bash\", \"/tmp/entrypoint.sh\"]"
   ]
 }

--- a/ctp.pkr.hcl
+++ b/ctp.pkr.hcl
@@ -35,8 +35,7 @@ variable "tag" {
   type = list(string)
 }
 source "docker" "debian" {
-  image = "openjdk:18-jdk-slim-bullseye"
-  # image = "openjdk:8u322-jdk-slim-bullseye"
+  image = "openjdk:8u322-jdk-slim-bullseye"
   commit  = true
   changes = [
     "LABEL org.opencontainers.image.source https://github.com/australian-imaging-service/ctp-build",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -x
 if [ ! -z $timezone ]; then
+  unlink /etc/localtime
   ln -s /usr/share/zoneinfo/$timezone /etc/localtime
 else
   echo "timezone environment variable is not set"


### PR DESCRIPTION
This includes following changes:
* use openjdk:8u322-jdk-slim-bullseye image
* use ctp installation jar from source repo, so that actual build date can be retrieved to tag container image properly
* fix packer build workflow


